### PR TITLE
Allowance for custom expanders when getting page by Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ Get stored content for a specific space and page title.
 | id | <code>string</code> | 
 | callback | <code>function</code> | 
 
+<a name="Confluence+getCustomContentById"></a>
+### confluence.getCustomContentById(options, callback)
+The options object format is as follows:
+{
+  id: "1234"              // Mandatory. page id from which to get content.
+  expanders: ['metadata'] // Optional. Array of content members to expand. Defaults to ['versions', 'body.storage']
+}
+
+**Kind**: instance method of <code>[Confluence](#Confluence)</code>  
+
+| Param | Type |
+| --- | --- |
+| options | <code>object</code> | 
+| callback | <code>function</code> | 
+
 <a name="Confluence+getContentByPageTitle"></a>
 ### confluence.getContentByPageTitle(space, title, callback)
 Get stored content for a specific space and page title.

--- a/lib/confluence.js
+++ b/lib/confluence.js
@@ -108,9 +108,14 @@ Confluence.prototype.getContentById = function(id, callback){
         .end(function(err, res){
             processCallback(callback, err, res);
         });
-
 };
 
+/**
+ * Get stored content for a specific page id with optional custom expanders.
+ *
+ * @param {object} options for the custom content request
+ * @param {Function} callback
+ */
 Confluence.prototype.getCustomContentById = function(options, callback) {
     var expanders = options.expanders || ['body.storage', 'version'];
 

--- a/lib/confluence.js
+++ b/lib/confluence.js
@@ -112,7 +112,14 @@ Confluence.prototype.getContentById = function(id, callback){
 };
 
 Confluence.prototype.getCustomContentById = function(options, callback) {
-    callback();
+    var expanders = options.expanders || ['body.storage', 'version'];
+
+    request
+        .get(this.config.baseUrl + "/rest/api/content/" + options.id + "?expand=" + expanders.join())
+        .auth(this.config.username, this.config.password)
+        .end(function(err, res){
+            processCallback(callback, err, res);
+        });
 }
 
 /**

--- a/lib/confluence.js
+++ b/lib/confluence.js
@@ -111,6 +111,10 @@ Confluence.prototype.getContentById = function(id, callback){
 
 };
 
+Confluence.prototype.getCustomContentById = function(options, callback) {
+    callback();
+}
+
 /**
  * Get stored content for a specific space and page title.
  *

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -117,6 +117,42 @@ describe('Confluence API', function () {
         });
     });
 
+    describe('#getCustomContentById', function() {
+
+        it('should get/read default expanded content', function(done) {
+            var confluence = new Confluence(config);
+            var options = {id: homePageId}
+            
+            confluence.getCustomContentById(options, function(err, data) {
+                expect(err).to.be.null;
+                expect(data).not.to.be.null;
+                expect(data.id).to.equal(homePageId);
+                expect(data.version).not.to.be.null;
+                expect(data.body.storage).not.to.be.null;
+                expect(data.body.metadata).to.be.undefined;
+                done();
+            });
+        });
+
+        it('should get/read explicit expander content', function(done) {
+            var confluence = new Confluence(config);
+            var options = {
+                id: homePageId,
+                expanders: ['version', 'metadata']
+            }
+            
+            confluence.getCustomContentById(options, function(err, data) {
+                expect(err).to.be.null;
+                expect(data).not.to.be.null;
+                expect(data.id).to.equal(homePageId);
+                expect(data.version).not.to.be.null;
+                expect(data.body).to.be.undefined;
+                expect(data.metadata).not.to.be.null;
+                done();
+            })
+        });
+    })
+
     describe('#getContentByPageTitle', function () {
         it('should get/read page content by space and title', function (done) {
             var confluence = new Confluence(config);


### PR DESCRIPTION
Created a new method named getCustomContentById which allows an object of options to be passed to the call. At the moment the object provides support for specifying explicit expanders. It could be expanded upon in the future to allow for even more parameters to be passed to the underlying querystring.

Perhaps for v2 of this module, getCustomContentById can be nuked, in favor of passing an object of options into get page by id.
