### PR TITLE
Confluence v4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ var Confluence = require("confluence-api");
 var config = {
     username: "testuser",
     password: "test-user-pw",
-    baseUrl:  "https://confluence-api-test.atlassian.net/wiki"
+    baseUrl:  "https://confluence-api-test.atlassian.net/wiki",
+    version: 4 // Confluence major version, optional
 };
 var confluence = new Confluence(config);
 confluence.getContentByPageTitle("space-name", "page-title", function(err, data) {
@@ -51,7 +52,7 @@ Construct Confluence.
 | config | <code>Object</code> | 
 | config.username | <code>string</code> | 
 | config.password | <code>string</code> | 
-| config.baseUrl | <code>string</code> | 
+| config.baseUrl | <code>string</code> |
 
 <a name="Confluence+getSpace"></a>
 ### confluence.getSpace(space, callback)

--- a/lib/confluence.js
+++ b/lib/confluence.js
@@ -62,7 +62,7 @@ function processCallback(cb, err, res) {
 Confluence.prototype.getSpace = function(space, callback){
 
     request
-        .get(this.config.baseUrl + this.apiPath + "/space?spaceKey=" + space)
+        .get(this.config.baseUrl + this.apiPath + "/space" + this.extension + "?spaceKey=" + space)
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);

--- a/lib/confluence.js
+++ b/lib/confluence.js
@@ -35,12 +35,12 @@ function Confluence(config) {
 
     this.config = config;
 
-    this.apiPath = '/rest/api';
-    this.extension = ''; // no extension by default
+    this.config.apiPath = '/rest/api';
+    this.config.extension = ''; // no extension by default
 
     if (this.config.version && this.config.version === 4) {
-        this.apiPath = '/rest/prototype/latest';
-        this.extension = '.json';
+        this.config.apiPath = '/rest/prototype/latest';
+        this.config.extension = '.json';
     }
 }
 
@@ -62,7 +62,7 @@ function processCallback(cb, err, res) {
 Confluence.prototype.getSpace = function(space, callback){
 
     request
-        .get(this.config.baseUrl + this.apiPath + "/space" + this.extension + "?spaceKey=" + space)
+        .get(this.config.baseUrl + this.config.apiPath + "/space" + this.config.extension + "?spaceKey=" + space)
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);
@@ -80,7 +80,7 @@ Confluence.prototype.getSpaceHomePage = function(space, callback){
     var config = this.config;
 
     request
-        .get(config.baseUrl + this.apiPath + "/space" + this.extension + "?spaceKey=" + space)
+        .get(config.baseUrl + config.apiPath + "/space" + config.extension + "?spaceKey=" + space)
         .auth(config.username, config.password)
         .end(function(err, res){
             if (err) {
@@ -112,7 +112,7 @@ Confluence.prototype.getSpaceHomePage = function(space, callback){
 Confluence.prototype.getContentById = function(id, callback){
 
     request
-        .get(this.config.baseUrl + this.apiPath + "/content/" + id + this.extension + "?expand=body.storage,version")
+        .get(this.config.baseUrl + this.config.apiPath + "/content/" + id + this.config.extension + "?expand=body.storage,version")
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);
@@ -129,7 +129,7 @@ Confluence.prototype.getCustomContentById = function(options, callback) {
     var expanders = options.expanders || ['body.storage', 'version'];
 
     request
-        .get(this.config.baseUrl + this.apiPath + "/content/" + options.id + this.extension + "?expand=" + expanders.join())
+        .get(this.config.baseUrl + this.config.apiPath + "/content/" + options.id + this.config.extension + "?expand=" + expanders.join())
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);
@@ -150,7 +150,7 @@ Confluence.prototype.getContentByPageTitle = function(space, title, callback){
         "&expand=body.storage,version";
 
     request
-        .get(this.config.baseUrl + this.apiPath + "/content" + this.extension + query)
+        .get(this.config.baseUrl + this.config.apiPath + "/content" + this.config.extension + query)
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);
@@ -188,7 +188,7 @@ Confluence.prototype.postContent = function(space, title, content, parentId, cal
 
     function createPage() {
         request
-            .post(config.baseUrl + this.apiPath + "/content" + this.extension)
+            .post(config.baseUrl + config.apiPath + "/content" + config.extension)
             .auth(config.username, config.password)
             .type('json')
             .send(page)
@@ -247,7 +247,7 @@ Confluence.prototype.putContent = function(space, id, version, title, content, c
     };
 
     request
-        .put(this.config.baseUrl + this.apiPath + "/content/" + id + this.extension + "?expand=body.storage,version")
+        .put(this.config.baseUrl + this.config.apiPath + "/content/" + id + this.config.extension + "?expand=body.storage,version")
         .auth(this.config.username, this.config.password)
         .type('json')
         .send(page)
@@ -266,7 +266,7 @@ Confluence.prototype.putContent = function(space, id, version, title, content, c
 Confluence.prototype.deleteContent = function(id, callback){
 
     request
-        .del(this.config.baseUrl + this.apiPath + "/content/" + id + this.extension)
+        .del(this.config.baseUrl + this.config.apiPath + "/content/" + id + this.config.extension)
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             callback(err, res);

--- a/lib/confluence.js
+++ b/lib/confluence.js
@@ -17,6 +17,7 @@ var request = require('superagent');
  * @param {string} config.username
  * @param {string} config.password
  * @param {string} config.baseUrl
+ * @param {integer} config.version
  *
  */
 function Confluence(config) {
@@ -33,6 +34,14 @@ function Confluence(config) {
     }
 
     this.config = config;
+
+    this.apiPath = '/rest/api';
+    this.extension = ''; // no extension by default
+
+    if (this.config.version && this.config.version === 4) {
+        this.apiPath = '/rest/prototype/latest';
+        this.extension = '.json';
+    }
 }
 
 function processCallback(cb, err, res) {
@@ -53,7 +62,7 @@ function processCallback(cb, err, res) {
 Confluence.prototype.getSpace = function(space, callback){
 
     request
-        .get(this.config.baseUrl + "/rest/api/space?spaceKey=" + space)
+        .get(this.config.baseUrl + this.apiPath + "/space?spaceKey=" + space)
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);
@@ -71,7 +80,7 @@ Confluence.prototype.getSpaceHomePage = function(space, callback){
     var config = this.config;
 
     request
-        .get(config.baseUrl + "/rest/api/space?spaceKey=" + space)
+        .get(config.baseUrl + this.apiPath + "/space" + this.extension + "?spaceKey=" + space)
         .auth(config.username, config.password)
         .end(function(err, res){
             if (err) {
@@ -103,7 +112,7 @@ Confluence.prototype.getSpaceHomePage = function(space, callback){
 Confluence.prototype.getContentById = function(id, callback){
 
     request
-        .get(this.config.baseUrl + "/rest/api/content/" + id + "?expand=body.storage,version")
+        .get(this.config.baseUrl + this.apiPath + "/content/" + id + this.extension + "?expand=body.storage,version")
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);
@@ -120,7 +129,7 @@ Confluence.prototype.getCustomContentById = function(options, callback) {
     var expanders = options.expanders || ['body.storage', 'version'];
 
     request
-        .get(this.config.baseUrl + "/rest/api/content/" + options.id + "?expand=" + expanders.join())
+        .get(this.config.baseUrl + this.apiPath + "/content/" + options.id + this.extension + "?expand=" + expanders.join())
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);
@@ -141,7 +150,7 @@ Confluence.prototype.getContentByPageTitle = function(space, title, callback){
         "&expand=body.storage,version";
 
     request
-        .get(this.config.baseUrl + "/rest/api/content" + query)
+        .get(this.config.baseUrl + this.apiPath + "/content" + this.extension + query)
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             processCallback(callback, err, res);
@@ -179,7 +188,7 @@ Confluence.prototype.postContent = function(space, title, content, parentId, cal
 
     function createPage() {
         request
-            .post(config.baseUrl + "/rest/api/content")
+            .post(config.baseUrl + this.apiPath + "/content" + this.extension)
             .auth(config.username, config.password)
             .type('json')
             .send(page)
@@ -238,7 +247,7 @@ Confluence.prototype.putContent = function(space, id, version, title, content, c
     };
 
     request
-        .put(this.config.baseUrl + "/rest/api/content/" + id + "?expand=body.storage,version")
+        .put(this.config.baseUrl + this.apiPath + "/content/" + id + this.extension + "?expand=body.storage,version")
         .auth(this.config.username, this.config.password)
         .type('json')
         .send(page)
@@ -257,7 +266,7 @@ Confluence.prototype.putContent = function(space, id, version, title, content, c
 Confluence.prototype.deleteContent = function(id, callback){
 
     request
-        .del(this.config.baseUrl + "/rest/api/content/" + id)
+        .del(this.config.baseUrl + this.apiPath + "/content/" + id + this.extension)
         .auth(this.config.username, this.config.password)
         .end(function(err, res){
             callback(err, res);


### PR DESCRIPTION
Since version 5.5, Confluence changed REST API path from '/rest/api-name/api-version' (e.g. /rest/prototype/latest) to simple '/rest/api'. Also they changed default output format from XML to JSON.

We can add support for Confluence v[4 - 5.4] REST APIs by manipulating resource URIs:
- change API path for v4;
- add '.json' to resource URI for v4;
