### PR TITLE
Add representation to content

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Get stored content for a specific space and page title.
 
 <a name="Confluence+postContent"></a>
 
-### confluence.postContent(space, title, content, parentId, callback)
+### confluence.postContent(space, title, content, parentId, callback, representation)
 Post content to a new page.
 
 **Kind**: instance method of [<code>Confluence</code>](#Confluence)
@@ -140,10 +140,11 @@ Post content to a new page.
 | content | <code>string</code> |  |
 | parentId | <code>number</code> | A null value will cause the page to be added under the space's home page |
 | callback | <code>function</code> |  |
+| representation | <code>string</code> | Optional value that will change the type of content (Wiki, Storage, etc.) |
 
 <a name="Confluence+putContent"></a>
 
-### confluence.putContent(space, id, version, title, content, callback, minorEdit)
+### confluence.putContent(space, id, version, title, content, callback, minorEdit, representation)
 Put/update stored content for a page.
 
 **Kind**: instance method of [<code>Confluence</code>](#Confluence)
@@ -157,6 +158,7 @@ Put/update stored content for a page.
 | content | <code>string</code> |  |
 | callback | <code>function</code> |  |
 | minorEdit | <code>boolean</code> | Optional |
+| representation | <code>string</code> | Optional value that will change the type of content (Wiki, Storage, etc.) |
 
 <a name="Confluence+deleteContent"></a>
 

--- a/lib/confluence.js
+++ b/lib/confluence.js
@@ -167,7 +167,7 @@ Confluence.prototype.getContentByPageTitle = function(space, title, callback){
  * @param {number} parentId - A null value will cause the page to be added under the space's home page
  * @param {Function} callback
  */
-Confluence.prototype.postContent = function(space, title, content, parentId, callback){
+Confluence.prototype.postContent = function(space, title, content, parentId, callback, representation){
     var config = this.config;
     var page = {
         "type": "page",
@@ -181,7 +181,7 @@ Confluence.prototype.postContent = function(space, title, content, parentId, cal
         "body": {
             "storage": {
                 "value": content,
-                "representation": "storage"
+                "representation": representation || "storage"
             }
         }
     };
@@ -227,7 +227,7 @@ Confluence.prototype.postContent = function(space, title, content, parentId, cal
  * @param {Function} callback
  * @param {boolean} minorEdit - Optional
  */
-Confluence.prototype.putContent = function(space, id, version, title, content, callback, minorEdit){
+Confluence.prototype.putContent = function(space, id, version, title, content, callback, minorEdit, representation){
     var page = {
         "id": id,
         "type": "page",
@@ -242,7 +242,7 @@ Confluence.prototype.putContent = function(space, id, version, title, content, c
         "body": {
             "storage": {
                 "value": content,
-                "representation": "storage"
+                "representation": representation || "storage"
             }
         }
     };

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -184,6 +184,18 @@ describe('Confluence API', function () {
                 done();
             });
         });
+
+        it('should put/update wiki content', function (done) {
+            var confluence = new Confluence(config);
+            version++;
+            pageContent = "h1. Header 1";
+            confluence.putContent(space, newPageId, version, title, pageContent, function(err, data) {
+                expect(err).to.be.null;
+                expect(data).not.to.be.null;
+                expect(data.body.storage.value).to.equal("<h1>Header 1</h1>");
+                done();
+            }, null, "wiki");
+        });
     });
 
 


### PR DESCRIPTION
This PR allows the user to change the representation of the content.  Currently, the default is just plain "storage" but there are other types available.  Setting the representation to "wiki" allows you to post tables (and other things) in a more comfortable format.

NOTE: I tried to model the change after the recent "minorEdit" change of the same nature.