### PR TITLE
Update documentation to include REST API Token information

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Install confluence-api via npm:
 $ npm install confluence-api
 ```
 
-Create an instance of Confluence by providing a username and password (Confluence uses basic http authentication) and a baseUrl used for all future requests.  For instance:
+Create an instance of Confluence by providing a username and password (or token) and a baseUrl used for all future requests.  Confluence uses [basic http authentication](https://developer.atlassian.com/cloud/confluence/basic-auth-for-rest-apis/). For instance:
 ```javascript
 var Confluence = require("confluence-api");
 var config = {
     username: "testuser",
-    password: "test-user-pw",
+    password: "test-user-pw-or-rest-api-token",
     baseUrl:  "https://confluence-api-test.atlassian.net/wiki",
     version: 4 // Confluence major version, optional
 };
@@ -61,7 +61,7 @@ Construct Confluence.
 | --- | --- | --- |
 | config | <code>Object</code> |  |
 | config.username | <code>string</code> |  |
-| config.password | <code>string</code> |  |
+| config.password | <code>string</code> | The password or REST API Token for the user ([docs](https://developer.atlassian.com/cloud/confluence/basic-auth-for-rest-apis/)) |
 | config.baseUrl | <code>string</code> |  |
 | config.version | <code>number</code> | Optional |
 


### PR DESCRIPTION
We prefer to use the REST API token instead of the user's password to authenticate. Luckily, this is supported out-of-the-box with the SuperAgent auth method you're using as part of this package. However, it did take me a little bit to recognize that it would work.

This PR updates the documentation to explicitly call out that you can pass a token in the "password" field.

Thank you for this handy library!